### PR TITLE
remove feature link from footer

### DIFF
--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -49,12 +49,6 @@ const Footer = () => {
                 </Link>
               </li>
               <li>
-                <Link to="/features" className="text-blue-100 hover:text-white transition flex items-start">
-                  <span className="w-1 h-1 mt-2 mr-2 bg-blue-400 rounded-full"></span>
-                  Features
-                </Link>
-              </li>
-              <li>
                 <Link to="/contact" className="text-blue-100 hover:text-white transition flex items-start">
                   <span className="w-1 h-1 mt-2 mr-2 bg-blue-400 rounded-full"></span>
                   Contact


### PR DESCRIPTION
### Target issue
#33 Remove feature link from footer

### Description 
There was no features page and link was re-directing nowhere so i removed it. 

### File changed
src/components/footer.jsx

### Screenshots
- before
 
<img width="1000" height="800" alt="Screenshot 2025-07-25 123207" src="https://github.com/user-attachments/assets/5bcba564-6c59-4160-9956-9790d64725a3" />

- After

<img width="1000" height="800" alt="Screenshot 2025-07-26 185118" src="https://github.com/user-attachments/assets/a564e5d0-2b8b-4e49-baff-8e146e754fe8" />
