### PR TITLE
Fix footer subscribe button left border radius

### DIFF
--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -104,7 +104,7 @@ const Footer = () => {
               />
               <button
                 type="submit"
-                className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-r-md transition"
+                className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md transition"
               >
                 Subscribe
               </button>


### PR DESCRIPTION

### Target issue
#34 Inconsistent button styling in footer

### Description 
Fixed the left top and bottom border radius of subscribe button by removing "-r" from rounded tailwind class in footer.

### File changed
src/components/footer.jsx

### Screenshot
- before
<img width="400" height="300" alt="Screenshot 2025-07-25 123617" src="https://github.com/user-attachments/assets/5b9990fc-d6fe-4bcf-931c-34da897e7852" />

- After
<img width="400" height="300" alt="Screenshot 2025-07-26 185712" src="https://github.com/user-attachments/assets/fb409682-1ce4-48ab-8fb8-2e96aec5dd8f" />